### PR TITLE
public access, access logging, and request metrics for product bucket

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -27,7 +27,7 @@ Resources:
     Properties:
       LoggingConfiguration:
         DestinationBucketName: !Ref LogBucket
-        LogFilePrefix: s3-access-logs/product-bucket/
+        LogFilePrefix: s3-access-logs/
       MetricsConfigurations:
         - Id: EntireBucket
       PublicAccessBlockConfiguration:

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -12,8 +12,45 @@ Parameters:
     Type: String
 
 Resources:
+  LogBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: LogDeliveryWrite
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        IgnorePublicAcls: True
+        BlockPublicPolicy: True
+        RestrictPublicBuckets: True
+
   ProductBucket:
     Type: AWS::S3::Bucket
+    Properties:
+      LoggingConfiguration:
+        DestinationBucketName: !Ref LogBucket
+        LogFilePrefix: s3-access-logs/product-bucket/
+      MetricsConfigurations:
+        - Id: EntireBucket
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        IgnorePublicAcls: True
+        BlockPublicPolicy: False
+        RestrictPublicBuckets: False
+
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ProductBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: "*"
+            Action: s3:ListBucket
+            Resource: !GetAtt ProductBucket.Arn
+          - Effect: Allow
+            Principal: "*"
+            Action: s3:GetObject
+            Resource: !Sub "${ProductBucket.Arn}/*"
 
   EventTable:
     Type: AWS::DynamoDB::Table

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -27,7 +27,7 @@ Resources:
     Properties:
       LoggingConfiguration:
         DestinationBucketName: !Ref LogBucket
-        LogFilePrefix: s3-access-logs/
+        LogFilePrefix: s3-access-logs/product-bucket/
       MetricsConfigurations:
         - Id: EntireBucket
       PublicAccessBlockConfiguration:


### PR DESCRIPTION
`PublicAccessBlockConfiguration` and `BucketPolicy` enable public list/get access to the product bucket.

`LoggingConfiguration` and `LogBucket` enable S3 access logging for the product bucket.
https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html#server-access-logging-overview

`MetricsConfigurations` enables collection of s3 request metrics for the product bucket in cloudwatch
https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html